### PR TITLE
Build from https clone

### DIFF
--- a/buildjobs.groovy
+++ b/buildjobs.groovy
@@ -27,7 +27,7 @@ recipePath = new File(rootPath, 'recipes')
 testShellTemplate = engine.createTemplate('''
 if [ ! -d ${testGithubProject} ];
 then
-    git clone --recursive git://github.com/${testGithubOrg}/${testGithubProject}.git
+    git clone --recursive https://github.com/${testGithubOrg}/${testGithubProject}.git
 fi
 cd ${testGithubProject};
 git pull;


### PR DESCRIPTION
I don't think using git has any advantage here. Otherwise I'm getting:

```
Cloning into 'galaxy-community-qa'...
Submodule 'just-dockerfiles' (git@github.com:jmchilton/just-dockerfiles.git) registered for path 'just-dockerfiles'
Cloning into 'just-dockerfiles'...
Host key verification failed.
fatal: Could not read from remote repository.
```
