### PR TITLE
Use native traceback to avoid leaking credentials

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ dump-description: setup-venv # Dump JSON description of recipe
 	$(IN_VENV) python dump.py $(RECIPE_NAME) --description
 
 run-test: setup-venv # Run a test.
-	$(IN_VENV) py.test run_test.py --timeout=$(shell $(IN_VENV) python dump.py $(RECIPE_NAME) --timeout) --verbose -k $(RECIPE_NAME) --junit-xml $(REPORT)
+	$(IN_VENV) py.test run_test.py --tb=native --timeout=$(shell $(IN_VENV) python dump.py $(RECIPE_NAME) --timeout) --verbose -k $(RECIPE_NAME) --junit-xml $(REPORT)

--- a/test.bash
+++ b/test.bash
@@ -8,5 +8,5 @@ cd `dirname $0`
 RECIPE_DIRECTORY="tests/recipes"
 export RECIPE_DIRECTORY
 
-py.test run_test.py -k 'test_test1'
-! py.test run_test.py -k 'test_test2'
+py.test --tb=native run_test.py -k 'test_test1'
+! py.test --tb=native run_test.py -k 'test_test2'


### PR DESCRIPTION
I'm using just-dockerfiles to test GalaxyKickStart cloud deployment (and Im working on workflow testing as well ...), so I've setup jenkins to test PRs. I have some credentials in here, that will unfortunately get leaked with the default pytest traceback formatting.

With this change, the traceback changes from sth. like:

```
Stacktrace

path = '/var/jenkins_home/workspace/gx-kickstart-qa-kickstart/tests/recipes/kickstart'

    def _t_function(path):
        recipe_config_path = os.path.join(path, "def.yml")
        if os.path.exists(recipe_config_path):
            with open(recipe_config_path, "r") as f:
                recipe_config = yaml.load(f)
        else:
            recipe_config = {}

        target_path = _get_defaultable_option(recipe_config, "targetPath", "/app")
        target_root = os.getenv("TARGET_ROOT", os.path.join(PROJECT_DIRECTORY, ".."))

        docker_image_id = str(uuid.uuid4())
        recipe_type = _recipe_type(path, recipe_config)
        if recipe_type == "dockerfile":
            _check_call(["docker", "build", "-t", docker_image_id, "."], cwd=path)
            _check_call(["docker", "run", "-v", "%s:%s" % (target_root, target_path), "--rm", "-t", docker_image_id], cwd=path)
        else:
            compose_args = []
            common_docker_compose_path = os.path.join(path, "common-docker-compose.yml")
            docker_compose_path = os.path.join(path, "docker-compose.yml")
            if os.path.exists(common_docker_compose_path):
                compose_args.extend(["-f", common_docker_compose_path])

            compose_args.extend(["-f", docker_compose_path])
            compose_args.extend(["-p", docker_image_id])

            compose_kwd = {
                'cwd': path,
                'env': {
                    'TARGET_PATH': target_path,
                    'TARGET_ROOT': target_root,
                }
            }

            try:
                try:
                    _check_call_flattened(["docker-compose", compose_args, "build", "test"], **compose_kwd)
>                   _check_call_flattened(["docker-compose", compose_args, "run", "test"], **compose_kwd)

run_test.py:65: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
run_test.py:100: in _check_call_flattened
    _check_call(flat_cmd, *args, **kwd)
run_test.py:107: in _check_call
    ret = subprocess.check_call(cmd, cwd=cwd, shell=False, env=new_env)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

popenargs = (['docker-compose', '-f', '/var/jenkins_home/workspace/gx-kickstart-qa-kickstart/tests/recipes/kickstart/docker-compose.yml', '-p', 'cea03c30-be5f-4945-83f4-1f3b6a5cf43f', 'run', ...],)
kwargs = {'cwd': '/var/jenkins_home/workspace/gx-kickstart-qa-kickstart/tests/recipes/kickstart', 'env': {'ANSIBLE_VAULT_PASWOR...BIOBLEND_GALAXY_API_KEY': 'admin', 'BUILD_CAUSE': 'GHPRBCAUSE', 'BUILD_CAUSE_GHPRBCAUSE': 'true', ...}, 'shell': False}
retcode = 2
cmd = ['docker-compose', '-f', '/var/jenkins_home/workspace/gx-kickstart-qa-kickstart/tests/recipes/kickstart/docker-compose.yml', '-p', 'cea03c30-be5f-4945-83f4-1f3b6a5cf43f', 'run', ...]

    def check_call(*popenargs, **kwargs):
        """Run command with arguments.  Wait for command to complete.  If
        the exit code was zero then return, otherwise raise
        CalledProcessError.  The CalledProcessError object will have the
        return code in the returncode attribute.

        The arguments are the same as for the Popen constructor.  Example:

        check_call(["ls", "-l"])
        """
        retcode = call(*popenargs, **kwargs)
        if retcode:
            cmd = kwargs.get("args")
            if cmd is None:
                cmd = popenargs[0]
>           raise CalledProcessError(retcode, cmd)
E           CalledProcessError: Command '['docker-compose', '-f', '/var/jenkins_home/workspace/gx-kickstart-qa-kickstart/tests/recipes/kickstart/docker-compose.yml', '-p', 'cea03c30-be5f-4945-83f4-1f3b6a5cf43f', 'run', 'test']' returned non-zero exit status 2

/usr/lib/python2.7/subprocess.py:540: CalledProcessError
```

to 

```
Stacktrace

Traceback (most recent call last):
  File "/var/jenkins_home/workspace/gx-kickstart-qa-kickstart/tests/just-dockerfiles/run_test.py", line 65, in _t_function
    _check_call_flattened(["docker-compose", compose_args, "run", "test"], **compose_kwd)
  File "/var/jenkins_home/workspace/gx-kickstart-qa-kickstart/tests/just-dockerfiles/run_test.py", line 100, in _check_call_flattened
    _check_call(flat_cmd, *args, **kwd)
  File "/var/jenkins_home/workspace/gx-kickstart-qa-kickstart/tests/just-dockerfiles/run_test.py", line 107, in _check_call
    ret = subprocess.check_call(cmd, cwd=cwd, shell=False, env=new_env)
  File "/usr/lib/python2.7/subprocess.py", line 540, in check_call
    raise CalledProcessError(retcode, cmd)
CalledProcessError: Command '['docker-compose', '-f', '/var/jenkins_home/workspace/gx-kickstart-qa-kickstart/tests/recipes/kickstart/docker-compose.yml', '-p', '05469457-827a-45f9-a949-39816da1f1dc', 'run', 'test']' returned non-zero exit status 2
```
